### PR TITLE
[어드민] 회원 관리 페이지 만들기 

### DIFF
--- a/src/main/resources/templates/admin/members.html
+++ b/src/main/resources/templates/admin/members.html
@@ -1,10 +1,67 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head>
+<head id="layout-head">
     <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+    <title>어드민 회원 페이지</title>
 
+    <link rel="stylesheet" href="/js/plugins/jsgrid/jsgrid.min.css">
+    <link rel="stylesheet" href="/js/plugins/jsgrid/jsgrid-theme.min.css">
+</head>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+    <header id="layout-header">헤더 삽입부</header>
+    <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+    <!-- Main content -->
+    <main id="layout-main">
+        <div id="jsgrid-admin-members"></div>
+    </main>
+    <!-- /.content -->
+
+    <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+    <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+<script src="/js/plugins/jsgrid/jsgrid.min.js"></script>
+<script>
+    $(function () {
+        $("#jsgrid-admin-members").jsGrid({
+            height: "100%",
+            width: "100%",
+
+            inserting: true,
+            editing: true,
+            sorting: true,
+            paging: false,
+
+            data: [
+                {
+                    "userId": "uno",
+                    "nickname": "Uno",
+                    "email": "uno@email.com",
+                    "memo": "test memo.",
+                    "roleTypes": "ADMIN",
+                    "createdBy": "Uno",
+                    "createdAt": "2022-01-01 00:00:00"
+                }
+            ],
+
+            fields: [
+                { name: "userId", title: "유저 ID", type: "text", width: 70 },
+                { name: "nickname", title: "닉네임", type: "text", width: 60 },
+                { name: "email", title: "이메일", type: "text", width: 120 },
+                { name: "memo", title: "메모", type: "text", width: 150 },
+                { name: "roleTypes", title: "권한", type: "select", items: [{"name": "ADMIN", "description": "관리자"}], valueField: "name", textField: "description", width: 100 },
+                { name: "createdBy", title: "작성자", type: "text", width: 60 },
+                { name: "createdAt", title: "작성일시", type: "text", width: 100 },
+                { type: "control" }
+            ]
+        });
+    });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/members.th
+++ b/src/main/resources/templates/admin/members.th
@@ -3,7 +3,7 @@
     <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
     <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
     <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('댓글 관리', (~{::#main-table} ?: ~{}))" />
+    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('어드민 회원', (~{::#jsgrid-admin-members} ?: ~{}))" />
     <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
     <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
     <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />

--- a/src/main/resources/templates/management/article-comments.html
+++ b/src/main/resources/templates/management/article-comments.html
@@ -27,19 +27,19 @@
             <tbody>
             <tr>
                 <td>1</td>
-                <td><a data-toggle="modal" data-target="#layout-modal">테스트 댓글입니다.</a></td>
+                <td>테스트 댓글입니다.</td>
                 <td>Uno</td>
                 <td><time datetime="2022-01-01T00:00:00">2022-01-01 00:00:00</time></td>
             </tr>
             <tr>
                 <td>2</td>
-                <td><a data-toggle="modal" data-target="#layout-modal">퍼가요~~</a></td>
+                <td>퍼가요~~</td>
                 <td>Uno</td>
                 <td><time datetime="2022-01-02T00:00:00">2022-01-02 00:00:00</time></td>
             </tr>
             <tr>
                 <td>3</td>
-                <td><a data-toggle="modal" data-target="#layout-modal">악성 댓글 XXX</a></td>
+                <td>악성 댓글 XXX</td>
                 <td>Uno</td>
                 <td><time datetime="2022-01-03T00:00:00">2022-01-03 00:00:00</time></td>
             </tr>
@@ -55,9 +55,6 @@
         </table>
     </main>
     <!-- /.content -->
-
-    <div class="modal fade" id="layout-modal"></div>
-    <!-- /.modal -->
 
     <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
     <footer id="layout-footer">푸터 삽입부</footer>
@@ -86,24 +83,6 @@
             "buttons": ["copy", "csv", "excel", "pdf", "print", "colvis"],
             "pageLength": 10
         }).buttons().container().appendTo('#main-table_wrapper .col-md-6:eq(0)'); // main-table_wrapper ID는 플러그인에 의해 자동 생성됨
-    });
-</script>
-<script>
-    $(document).ready(() => {
-        $('#layout-modal').on('show.bs.modal', (event) => {
-            const id = $(event.relatedTarget).data('id');
-
-            fetch(`/management/article-comments/${id}`)
-                .then(response => response.json())
-                .then(data => {
-                    $('.modal-title').text('댓글 내용');
-                    $('.modal-body pre').text(data.content);
-                    $('.modal-footer form').attr('action', `/management/article-comments/${id}`);
-                })
-                .catch(error => {
-                    console.error('댓글 로딩 실패: ', error);
-                });
-        });
     });
 </script>
 </body>


### PR DESCRIPTION
이 pr은 회원 관리 페이지, 어드민 회원 페이지에 공통 레이아웃을 이용해 디자인을 입히고,
데이터 테이블을 자바스크립트 플러그인을 사용해 그려낸다.
JsGrid 테이블을 도입하고, 이를 위해 해당 플러그인을 추가한다.

This closes #19 